### PR TITLE
fix: Slack/Notion/HubSpot コネクタの品質改善

### DIFF
--- a/backend/app/infrastructure/connectors/hubspot/polling.py
+++ b/backend/app/infrastructure/connectors/hubspot/polling.py
@@ -1,0 +1,157 @@
+# backend/app/infrastructure/connectors/hubspot/polling.py
+import logging
+from datetime import timezone
+
+import httpx
+
+from app.infrastructure.connectors.encryption import CredentialDecryptionError, decrypt_credentials
+from app.infrastructure.connectors.hubspot.handler import HubSpotConnector
+from app.infrastructure.db.database import async_session
+from app.infrastructure.repository.integration_repo import IntegrationRepository
+from app.infrastructure.repository.postgres import PostgresBugRepository
+from app.usecase.bug_usecase import BugUsecase
+
+logger = logging.getLogger(__name__)
+
+HUBSPOT_API = "https://api.hubapi.com"
+
+# Properties fetched from HubSpot CRM tickets endpoint
+_TICKET_PROPERTIES = [
+    "subject",
+    "content",
+    "hs_ticket_priority",
+    "hs_pipeline_stage",
+    "createdate",
+    "hs_lastmodifieddate",
+]
+
+
+async def _fetch_tickets_updated_since(
+    access_token: str, updated_after_ms: int | None
+) -> list[dict]:
+    """Fetch HubSpot tickets updated after the given Unix timestamp in milliseconds.
+
+    Uses the CRM search endpoint to filter by hs_lastmodifieddate.
+    Returns a list of ticket objects normalized to the webhook payload shape:
+    {"objectId": ..., "properties": {...}}.
+    """
+    headers = {
+        "Authorization": f"Bearer {access_token}",
+        "Content-Type": "application/json",
+    }
+    filters = []
+    if updated_after_ms is not None:
+        filters.append(
+            {
+                "propertyName": "hs_lastmodifieddate",
+                "operator": "GT",
+                "value": str(updated_after_ms),
+            }
+        )
+
+    search_body = {
+        "filterGroups": [{"filters": filters}] if filters else [],
+        "properties": _TICKET_PROPERTIES,
+        "limit": 100,
+        "sorts": [{"propertyName": "hs_lastmodifieddate", "direction": "ASCENDING"}],
+    }
+
+    try:
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            resp = await client.post(
+                f"{HUBSPOT_API}/crm/v3/objects/tickets/search",
+                headers=headers,
+                json=search_body,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            results = data.get("results", [])
+            # Normalize to the same shape that the webhook handler expects:
+            # {"objectId": "...", "properties": {...}}
+            return [
+                {"objectId": ticket["id"], "properties": ticket.get("properties", {})}
+                for ticket in results
+            ]
+    except httpx.HTTPError as exc:
+        logger.warning("HubSpot ticket fetch failed: %s", exc)
+        return []
+
+
+async def poll_hubspot_integrations() -> None:
+    """Poll all active HubSpot integrations for updated tickets. Called by APScheduler."""
+    async with async_session() as session:
+        integration_repo = IntegrationRepository(session)
+        bug_usecase = BugUsecase(PostgresBugRepository(session))
+        connector = HubSpotConnector()
+
+        integrations = await integration_repo.list_active_by_source("hubspot")
+        for integration in integrations:
+            try:
+                if integration.credentials_enc is None:
+                    logger.warning(
+                        "HubSpot integration %s has no credentials; skipping", integration.id
+                    )
+                    continue
+
+                try:
+                    credentials = decrypt_credentials(integration.credentials_enc)
+                except CredentialDecryptionError:
+                    logger.error(
+                        "HubSpot integration %s: credential decryption failed; skipping",
+                        integration.id,
+                    )
+                    await integration_repo.log_event(
+                        str(integration.id),
+                        "error",
+                        error_message="credential_decryption_failed",
+                    )
+                    continue
+
+                access_token = credentials.get("access_token", "")
+                if not access_token:
+                    logger.warning(
+                        "HubSpot integration %s has no access_token; skipping", integration.id
+                    )
+                    continue
+
+                # Convert last_received_at to milliseconds epoch for HubSpot filter
+                updated_after_ms: int | None = None
+                if integration.last_received_at:
+                    dt = integration.last_received_at
+                    if dt.tzinfo is None:
+                        dt = dt.replace(tzinfo=timezone.utc)
+                    updated_after_ms = int(dt.timestamp() * 1000)
+
+                tickets = await _fetch_tickets_updated_since(access_token, updated_after_ms)
+
+                for ticket in tickets:
+                    raw_ticket_id = str(ticket.get("objectId", ""))
+                    if not raw_ticket_id:
+                        continue
+
+                    source_ref = f"hubspot:ticket:{raw_ticket_id}"
+
+                    if await integration_repo.is_duplicate(str(integration.id), source_ref):
+                        continue
+
+                    if not await connector.should_process(ticket, integration.trigger_rules or {}):
+                        continue
+
+                    bug_create = await connector.transform(
+                        ticket, integration.field_mappings or []
+                    )
+                    bug = await bug_usecase.create_bug(bug_create)
+                    await integration_repo.log_event(
+                        str(integration.id),
+                        "created",
+                        source_ref=source_ref,
+                        bug_id=str(bug.id),
+                    )
+                    logger.info(
+                        "HubSpot ticket %s → Bug %s created", raw_ticket_id, bug.id
+                    )
+
+            except Exception:
+                logger.exception(
+                    "HubSpot polling failed for integration %s", integration.id
+                )

--- a/backend/app/infrastructure/connectors/notion/handler.py
+++ b/backend/app/infrastructure/connectors/notion/handler.py
@@ -116,10 +116,18 @@ class NotionConnector(ConnectorABC):
         }
         async with httpx.AsyncClient(timeout=10.0) as client:
             try:
-                await client.patch(
+                resp = await client.patch(
                     f"{NOTION_API}/pages/{page_id}",
                     headers=headers,
                     json={"properties": properties},
+                )
+                resp.raise_for_status()
+            except httpx.HTTPStatusError as exc:
+                logger.warning(
+                    "Failed to update Notion page %s: HTTP %s %s",
+                    page_id,
+                    exc.response.status_code,
+                    exc.response.text,
                 )
             except httpx.HTTPError as exc:
                 logger.warning("Failed to update Notion page %s: %s", page_id, exc)

--- a/backend/app/infrastructure/connectors/notion/polling.py
+++ b/backend/app/infrastructure/connectors/notion/polling.py
@@ -1,8 +1,8 @@
-# backend/app/connectors/notion/polling.py
+# backend/app/infrastructure/connectors/notion/polling.py
 import logging
-from datetime import timezone as _tz
+from datetime import datetime, timezone
 
-from app.infrastructure.connectors.encryption import decrypt_credentials
+from app.infrastructure.connectors.encryption import CredentialDecryptionError, decrypt_credentials
 from app.infrastructure.connectors.notion.handler import NotionConnector
 from app.infrastructure.db.database import async_session
 from app.infrastructure.repository.integration_repo import IntegrationRepository
@@ -10,6 +10,18 @@ from app.infrastructure.repository.postgres import PostgresBugRepository
 from app.usecase.bug_usecase import BugUsecase
 
 logger = logging.getLogger(__name__)
+
+
+def _to_utc_isoformat(dt: datetime) -> str:
+    """Convert a datetime to a UTC ISO 8601 string accepted by the Notion API.
+
+    Handles both timezone-aware and timezone-naive datetimes safely.
+    Naive datetimes are assumed to be UTC (consistent with PostgreSQL TIMESTAMP WITH TIME ZONE
+    returning UTC-aware values, but guarding against edge cases).
+    """
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc).isoformat()
 
 
 async def poll_notion_integrations() -> None:
@@ -22,15 +34,38 @@ async def poll_notion_integrations() -> None:
         integrations = await integration_repo.list_active_by_source("notion")
         for integration in integrations:
             try:
-                credentials = decrypt_credentials(integration.credentials_enc)
+                if integration.credentials_enc is None:
+                    logger.warning(
+                        "Notion integration %s has no credentials; skipping", integration.id
+                    )
+                    continue
+
+                try:
+                    credentials = decrypt_credentials(integration.credentials_enc)
+                except CredentialDecryptionError:
+                    logger.error(
+                        "Notion integration %s: credential decryption failed; skipping",
+                        integration.id,
+                    )
+                    await integration_repo.log_event(
+                        str(integration.id),
+                        "error",
+                        error_message="credential_decryption_failed",
+                    )
+                    continue
+
                 token = credentials.get("token", "")
                 rules = integration.trigger_rules or {}
                 database_id = rules.get("database_id", "")
                 if not database_id:
+                    logger.debug(
+                        "Notion integration %s has no database_id in trigger_rules; skipping",
+                        integration.id,
+                    )
                     continue
 
                 last_ts = (
-                    integration.last_received_at.astimezone(_tz.utc).isoformat()
+                    _to_utc_isoformat(integration.last_received_at)
                     if integration.last_received_at
                     else None
                 )
@@ -38,6 +73,8 @@ async def poll_notion_integrations() -> None:
 
                 for page in pages:
                     page_id = page.get("id", "")
+                    if not page_id:
+                        continue
                     source_ref = f"notion:page:{page_id}"
 
                     if await integration_repo.is_duplicate(str(integration.id), source_ref):
@@ -46,10 +83,14 @@ async def poll_notion_integrations() -> None:
                     bug_create = await connector.transform(page, integration.field_mappings or [])
                     bug = await bug_usecase.create_bug(bug_create)
                     await integration_repo.log_event(
-                        str(integration.id), "created",
-                        source_ref=source_ref, bug_id=str(bug.id)
+                        str(integration.id),
+                        "created",
+                        source_ref=source_ref,
+                        bug_id=str(bug.id),
                     )
                     logger.info("Notion page %s → Bug %s created", page_id, bug.id)
 
-            except Exception as e:
-                logger.exception("Notion polling failed for integration %s: %s", integration.id, e)
+            except Exception:
+                logger.exception(
+                    "Notion polling failed for integration %s", integration.id
+                )

--- a/backend/app/infrastructure/connectors/slack/client.py
+++ b/backend/app/infrastructure/connectors/slack/client.py
@@ -1,5 +1,9 @@
 # backend/app/connectors/slack/client.py
+import logging
+
 import httpx
+
+logger = logging.getLogger(__name__)
 
 SLACK_API = "https://slack.com/api"
 
@@ -9,32 +13,62 @@ class SlackClient:
         self._headers = {"Authorization": f"Bearer {bot_token}"}
 
     async def get_message(self, channel: str, ts: str) -> dict[str, object]:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.get(
-                f"{SLACK_API}/conversations.history",
-                headers=self._headers,
-                params={"channel": channel, "latest": ts, "inclusive": "true", "limit": "1"},
-            )
-            resp.raise_for_status()
-            data = resp.json()
-            messages = data.get("messages", [])
-            return messages[0] if messages else {}
+        """Fetch a single message from conversations.history.
+
+        Returns an empty dict if the message cannot be retrieved (HTTP error or Slack API error).
+        """
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                resp = await client.get(
+                    f"{SLACK_API}/conversations.history",
+                    headers=self._headers,
+                    params={"channel": channel, "latest": ts, "inclusive": "true", "limit": "1"},
+                )
+                resp.raise_for_status()
+                data = resp.json()
+                if not data.get("ok"):
+                    logger.warning(
+                        "Slack conversations.history returned ok=false for channel=%s ts=%s: %s",
+                        channel,
+                        ts,
+                        data.get("error"),
+                    )
+                    return {}
+                messages = data.get("messages", [])
+                return messages[0] if messages else {}
+        except httpx.HTTPError as exc:
+            logger.warning("Slack get_message failed for channel=%s ts=%s: %s", channel, ts, exc)
+            return {}
 
     async def get_user_name(self, user_id: str) -> str:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.get(
-                f"{SLACK_API}/users.info",
-                headers=self._headers,
-                params={"user": user_id},
-            )
-            resp.raise_for_status()
-            data = resp.json()
-            if not data.get("ok"):
-                return "unknown"
-            user = data["user"]
-            return user.get("real_name") or user.get("name", "unknown")
+        """Resolve a Slack user ID to a display name.
+
+        Returns "unknown" on any API or transport failure.
+        """
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                resp = await client.get(
+                    f"{SLACK_API}/users.info",
+                    headers=self._headers,
+                    params={"user": user_id},
+                )
+                resp.raise_for_status()
+                data = resp.json()
+                if not data.get("ok"):
+                    logger.warning(
+                        "Slack users.info returned ok=false for user=%s: %s",
+                        user_id,
+                        data.get("error"),
+                    )
+                    return "unknown"
+                user = data["user"]
+                return user.get("real_name") or user.get("name", "unknown")
+        except httpx.HTTPError as exc:
+            logger.warning("Slack get_user_name failed for user=%s: %s", user_id, exc)
+            return "unknown"
 
     async def post_thread_message(self, channel: str, thread_ts: str, text: str) -> None:
+        """Post a reply to a Slack thread. Raises httpx.HTTPError on failure."""
         async with httpx.AsyncClient(timeout=10.0) as client:
             resp = await client.post(
                 f"{SLACK_API}/chat.postMessage",
@@ -44,18 +78,33 @@ class SlackClient:
             resp.raise_for_status()
 
     async def test_auth(self) -> bool:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.get(f"{SLACK_API}/auth.test", headers=self._headers)
-            resp.raise_for_status()
-            return resp.json().get("ok", False)
+        """Return True if the bot token is valid, False on any error."""
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                resp = await client.get(f"{SLACK_API}/auth.test", headers=self._headers)
+                resp.raise_for_status()
+                return resp.json().get("ok", False)
+        except httpx.HTTPError as exc:
+            logger.warning("Slack test_auth failed: %s", exc)
+            return False
 
     async def list_channels(self) -> list[dict[str, str]]:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.get(
-                f"{SLACK_API}/conversations.list",
-                headers=self._headers,
-                params={"limit": "200", "types": "public_channel,private_channel"},
-            )
-            resp.raise_for_status()
-            data = resp.json()
-            return [{"id": c["id"], "name": c["name"]} for c in data.get("channels", [])]
+        """Return a list of accessible channels. Returns an empty list on failure."""
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                resp = await client.get(
+                    f"{SLACK_API}/conversations.list",
+                    headers=self._headers,
+                    params={"limit": "200", "types": "public_channel,private_channel"},
+                )
+                resp.raise_for_status()
+                data = resp.json()
+                if not data.get("ok"):
+                    logger.warning(
+                        "Slack conversations.list returned ok=false: %s", data.get("error")
+                    )
+                    return []
+                return [{"id": c["id"], "name": c["name"]} for c in data.get("channels", [])]
+        except httpx.HTTPError as exc:
+            logger.warning("Slack list_channels failed: %s", exc)
+            return []

--- a/backend/app/infrastructure/connectors/slack/verify.py
+++ b/backend/app/infrastructure/connectors/slack/verify.py
@@ -10,7 +10,16 @@ def verify_slack_signature(
     body: bytes,
     signature: str,
 ) -> bool:
-    """Verify Slack request signature (prevents spoofing)."""
+    """Verify Slack request signature (prevents spoofing).
+
+    Returns False immediately if any required input is missing, if the timestamp
+    is outside the 5-minute replay-attack window, or if the HMAC does not match.
+    """
+    # Reject requests with missing inputs to avoid accidentally passing validation
+    # when the integration is misconfigured (e.g., empty signing secret in DB).
+    if not signing_secret or not timestamp or not signature:
+        return False
+
     try:
         if abs(time.time() - float(timestamp)) > 300:
             return False  # Reject requests older than 5 minutes (replay attack prevention)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,6 +4,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from app.config import settings
 from app.infrastructure.connectors.hubspot.handler import HubSpotConnector
+from app.infrastructure.connectors.hubspot.polling import poll_hubspot_integrations
 from app.infrastructure.connectors.notion.handler import NotionConnector
 from app.infrastructure.connectors.notion.polling import poll_notion_integrations
 from app.infrastructure.connectors.registry import register_connector
@@ -47,6 +48,7 @@ async def startup() -> None:
     register_connector("hubspot", HubSpotConnector())
     register_connector("notion", NotionConnector())
     scheduler.add_job(poll_notion_integrations, "interval", minutes=5, id="notion_poll")
+    scheduler.add_job(poll_hubspot_integrations, "interval", minutes=5, id="hubspot_poll")
     scheduler.start()
 
 

--- a/backend/app/presentation/webhooks.py
+++ b/backend/app/presentation/webhooks.py
@@ -1,3 +1,6 @@
+# backend/app/presentation/webhooks.py
+import logging
+
 from fastapi import APIRouter, Depends, Request
 
 from app.di.bug import get_bug_usecase
@@ -7,6 +10,8 @@ from app.infrastructure.connectors.registry import get_connector
 from app.infrastructure.connectors.slack.handler import SlackConnector
 from app.infrastructure.repository.integration_repo import IntegrationRepository
 from app.usecase.bug_usecase import BugUsecase
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/webhooks", tags=["webhooks"])
 
@@ -62,7 +67,8 @@ async def slack_webhook(
             results.append("skipped")
             continue
 
-        # For reaction_added, fetch the original message
+        # For reaction_added, fetch the original message.
+        # get_message is now safe and returns {} on failure rather than raising.
         event_data = event
         if event.get("type") == "reaction_added":
             item = event.get("item", {})
@@ -70,7 +76,27 @@ async def slack_webhook(
                 channel=item.get("channel", ""),
                 ts=item.get("ts", ""),
             )
-            event_data = {**message, "channel": item.get("channel", ""), "user": event.get("user", "")}
+            if not message:
+                # Could not retrieve the original message; log and skip this event.
+                logger.warning(
+                    "reaction_added: could not fetch original message for integration=%s "
+                    "channel=%s ts=%s",
+                    integration.id,
+                    item.get("channel"),
+                    item.get("ts"),
+                )
+                await integration_repo.log_event(
+                    str(integration.id),
+                    "error",
+                    error_message="reaction_added: original message fetch failed",
+                )
+                results.append("error")
+                continue
+            event_data = {
+                **message,
+                "channel": item.get("channel", ""),
+                "user": event.get("user", ""),
+            }
 
         # Deduplicate
         ts = str(event_data.get("ts", ""))
@@ -90,6 +116,11 @@ async def slack_webhook(
             )
             results.append("created")
         except Exception as e:
+            logger.exception(
+                "Slack webhook: bug creation failed for integration=%s source_ref=%s",
+                integration.id,
+                source_ref,
+            )
             await integration_repo.log_event(
                 str(integration.id), "error", source_ref=source_ref, error_message=str(e)
             )
@@ -101,7 +132,7 @@ async def slack_webhook(
             await connector.client.post_thread_message(
                 channel=channel,
                 thread_ts=ts,
-                text=f"✅ Vigilにバグチケットを作成しました: {bug.title}",
+                text=f"Vigilにバグチケットを作成しました: {bug.title}",
             )
         except Exception:
             pass  # Non-fatal: ticket was already created successfully
@@ -132,9 +163,15 @@ async def hubspot_webhook(
             results.append("skipped")
             continue
 
-        ticket_id = str(json_body.get("objectId", ""))
-        if ticket_id and await integration_repo.is_duplicate(str(integration.id), ticket_id):
-            await integration_repo.log_event(str(integration.id), "duplicate", source_ref=ticket_id)
+        # Use the same "hubspot:ticket:{id}" format as transform() produces for external_ref,
+        # ensuring that is_duplicate, log_event, and external_ref are all consistent.
+        raw_ticket_id = str(json_body.get("objectId", ""))
+        source_ref = f"hubspot:ticket:{raw_ticket_id}" if raw_ticket_id else ""
+
+        if source_ref and await integration_repo.is_duplicate(str(integration.id), source_ref):
+            await integration_repo.log_event(
+                str(integration.id), "duplicate", source_ref=source_ref
+            )
             results.append("duplicate")
             continue
 
@@ -142,12 +179,17 @@ async def hubspot_webhook(
             bug_create = await connector.transform(json_body, integration.field_mappings or [])
             bug = await bug_usecase.create_bug(bug_create)
             await integration_repo.log_event(
-                str(integration.id), "created", source_ref=ticket_id, bug_id=str(bug.id)
+                str(integration.id), "created", source_ref=source_ref, bug_id=str(bug.id)
             )
             results.append("created")
         except Exception as e:
+            logger.exception(
+                "HubSpot webhook: bug creation failed for integration=%s source_ref=%s",
+                integration.id,
+                source_ref,
+            )
             await integration_repo.log_event(
-                str(integration.id), "error", source_ref=ticket_id, error_message=str(e)
+                str(integration.id), "error", source_ref=source_ref, error_message=str(e)
             )
             results.append("error")
 


### PR DESCRIPTION
## 発見した問題点

### セキュリティ
- **[slack/verify.py]** `signing_secret` / `timestamp` / `signature` のいずれかが空文字のとき、HMAC 計算が通り `compare_digest` に空文字列が渡される可能性があった。設定ミスで意図せず検証が通るリスクがあった。

### バグ・クラッシュ
- **[webhooks.py / HubSpot]** `is_duplicate` と `log_event` に渡す `source_ref` がローカル変数 `ticket_id`（生の数値文字列）で、`transform()` が生成する `external_ref`（`"hubspot:ticket:{id}"` 形式）と不整合だった。重複検知のキーが `external_ref` 形式と一致しない状態だった。
- **[webhooks.py / Slack]** `reaction_added` イベントで `get_message()` が例外を投げた場合、外側の try-except がないためリクエスト全体が 500 エラーになっていた。
- **[notion/polling.py]** `integration.last_received_at` が timezone-naive の場合、`astimezone()` の呼び出しが `TypeError` でクラッシュする可能性があった。

### エラーハンドリングの欠落
- **[slack/client.py]** `get_message` / `get_user_name` / `test_auth` / `list_channels` の全メソッドで `httpx.HTTPError` をキャッチしていなかった。Slack API が 4xx/5xx を返したりタイムアウトした場合、例外が上位に伝搬して処理全体がクラッシュしていた。
- **[slack/client.py]** `get_message` で Slack API の `ok: false` レスポンスをチェックしていなかった（HTTP 200 でも `ok: false` が返ることがある）。
- **[notion/handler.py]** `update_page` で `raise_for_status()` を呼ばないため、HTTP 4xx/5xx エラーが静かに無視されていた。
- **[notion/polling.py]** `credentials_enc` が `None` の統合と `CredentialDecryptionError` を個別にハンドリングしておらず、`integration_events` にエラーが記録されなかった。

### 未実装機能
- **[hubspot/polling.py]** HubSpot はポーリングベースとコメントされていたが、実際にはポーリング実装が存在しなかった（Notion と同様の実装が必要だった）。

---

## 対応した修正

### セキュリティ修正
- `slack/verify.py`: 入力が空の場合は早期 `return False` を追加

### バグ修正
- `webhooks.py` (HubSpot): `source_ref` を `"hubspot:ticket:{id}"` 形式に統一し、`is_duplicate` / `log_event` / `external_ref` の整合性を確保
- `webhooks.py` (Slack): `reaction_added` で `get_message` が空を返した場合、`integration_events` に `"error"` を記録してスキップするよう修正
- `notion/polling.py`: `_to_utc_isoformat()` ヘルパーを追加し、timezone-naive datetime を安全に UTC 変換

### エラーハンドリング追加
- `slack/client.py`: 全メソッドに `httpx.HTTPError` キャッチを追加。`ok: false` レスポンスも警告ログに記録
- `notion/handler.py`: `update_page` に `raise_for_status()` を追加し、HTTP エラー時にステータスコードとレスポンスボディをログに記録
- `notion/polling.py`: `credentials_enc` が None の場合と `CredentialDecryptionError` を個別にハンドリングし、エラーイベントを記録するよう修正
- `webhooks.py`: Slack / HubSpot の bug creation 失敗時に `logger.exception` でスタックトレースを記録

### 新規実装
- `hubspot/polling.py`: HubSpot CRM search API を使ったポーリング実装を新規追加（Notion 同様に APScheduler で 5 分ごとに実行）
- `main.py`: `poll_hubspot_integrations` を APScheduler に登録

🤖 Generated with [Claude Code](https://claude.com/claude-code)