### PR TITLE
feat: Notion連携改善 - trigger_rules フィルタ + field_mappings V2

### DIFF
--- a/backend/app/infrastructure/connectors/notion/handler.py
+++ b/backend/app/infrastructure/connectors/notion/handler.py
@@ -5,7 +5,7 @@ import httpx
 from fastapi import Request
 
 from app.infrastructure.connectors.base import ConnectorABC
-from app.domain.schemas import BugCreate, Priority, Severity, Source
+from app.domain.schemas import BugCreate, Category, Priority, Severity, Source
 
 logger = logging.getLogger(__name__)
 
@@ -19,44 +19,135 @@ class NotionConnector(ConnectorABC):
         return True  # Notion uses polling, not push webhooks
 
     async def should_process(self, event_data: dict, trigger_rules: dict) -> bool:
-        # Notion uses polling; page filtering is handled in polling.py by database_id selection.
+        # Notion uses polling; page filtering is handled in query_database via Notion API filters.
         # All pages returned by query_database are processed.
         return True
 
     async def transform(self, event_data: dict, field_mappings: list[dict]) -> BugCreate:
-        """Convert a Notion page object to BugCreate."""
-        # field_mappings are intentionally unused in V1; Notion fields are mapped by property type.
+        """Convert a Notion page object to BugCreate, applying field_mappings."""
         props = event_data.get("properties", {})
-
-        def get_title(prop: dict) -> str:
-            items = prop.get("title", [])
-            return "".join(t.get("plain_text", "") for t in items)
-
-        def get_rich_text(prop: dict) -> str:
-            items = prop.get("rich_text", [])
-            return "".join(t.get("plain_text", "") for t in items)
-
-        def get_select(prop: dict) -> str:
-            sel = prop.get("select") or {}
-            return sel.get("name", "")
-
-        # Default mapping: find "Name"/"Title" → title, "Description" → description
-        title = ""
-        description = ""
-        for key, val in props.items():
-            if val.get("type") == "title":
-                title = get_title(val)
-            elif key.lower() in ("description", "content", "説明"):
-                description = get_rich_text(val)
-
         page_id = event_data.get("id", "")
 
+        def extract_prop(prop_name: str) -> str | None:
+            """Extract a plain-text value from a Notion property by name."""
+            prop = props.get(prop_name)
+            if not prop:
+                return None
+            ptype = prop.get("type")
+            if ptype == "title":
+                items = prop.get("title", [])
+                return "".join(t.get("plain_text", "") for t in items) or None
+            elif ptype == "rich_text":
+                items = prop.get("rich_text", [])
+                return "".join(t.get("plain_text", "") for t in items) or None
+            elif ptype == "select":
+                sel = prop.get("select")
+                return sel.get("name") if sel else None
+            elif ptype == "multi_select":
+                items = prop.get("multi_select", [])
+                return ", ".join(i.get("name", "") for i in items) or None
+            elif ptype == "date":
+                date_obj = prop.get("date")
+                return date_obj.get("start") if date_obj else None
+            elif ptype == "number":
+                n = prop.get("number")
+                return str(n) if n is not None else None
+            elif ptype == "url":
+                return prop.get("url")
+            elif ptype == "email":
+                return prop.get("email")
+            elif ptype == "phone_number":
+                return prop.get("phone_number")
+            elif ptype == "checkbox":
+                return "true" if prop.get("checkbox") else "false"
+            return None
+
+        # Notion value → VIGIL Severity
+        _SEVERITY_MAP: dict[str, Severity] = {
+            "critical": Severity.CRITICAL, "Critical": Severity.CRITICAL,
+            "high": Severity.HIGH, "High": Severity.HIGH,
+            "medium": Severity.MEDIUM, "Medium": Severity.MEDIUM,
+            "normal": Severity.MEDIUM, "Normal": Severity.MEDIUM,
+            "low": Severity.LOW, "Low": Severity.LOW,
+        }
+
+        # Notion value → VIGIL Priority
+        _PRIORITY_MAP: dict[str, Priority] = {
+            "p0": Priority.P0, "P0": Priority.P0,
+            "p1": Priority.P1, "P1": Priority.P1,
+            "p2": Priority.P2, "P2": Priority.P2,
+            "p3": Priority.P3, "P3": Priority.P3,
+        }
+
+        # Notion value → VIGIL Category
+        _CATEGORY_MAP: dict[str, Category] = {
+            "ui": Category.UI, "UI": Category.UI,
+            "api": Category.API, "API": Category.API,
+            "type_error": Category.TYPE_ERROR,
+            "auth": Category.AUTH, "Auth": Category.AUTH,
+            "data": Category.DATA, "Data": Category.DATA,
+            "performance": Category.PERFORMANCE, "Performance": Category.PERFORMANCE,
+            "other": Category.OTHER, "Other": Category.OTHER,
+        }
+
+        # Defaults
+        title = ""
+        description: str | None = None
+        severity: Severity = Severity.MEDIUM
+        priority: Priority = Priority.P2
+        category: Category | None = None
+        version: str | None = None
+
+        if field_mappings:
+            # Apply custom mappings from integration config
+            for mapping in field_mappings:
+                src: str = mapping.get("from", "")
+                dst: str = mapping.get("to", "")
+                if not src or not dst:
+                    continue
+
+                if src.startswith("fixed_value:"):
+                    value: str | None = src.split(":", 1)[1]
+                elif src.startswith("properties."):
+                    prop_name = src.split(".", 1)[1]
+                    value = extract_prop(prop_name)
+                else:
+                    value = extract_prop(src)
+
+                if value is None:
+                    continue
+
+                if dst == "title":
+                    title = value[:200]
+                elif dst == "description":
+                    description = value
+                elif dst == "severity":
+                    severity = _SEVERITY_MAP.get(value, Severity.MEDIUM)
+                elif dst == "priority":
+                    priority = _PRIORITY_MAP.get(value, Priority.P2)
+                elif dst == "category":
+                    category = _CATEGORY_MAP.get(value)
+                elif dst == "version":
+                    version = value
+        else:
+            # V1 fallback: auto-detect title by property type, description by common names
+            for name, prop in props.items():
+                if prop.get("type") == "title" and not title:
+                    title = extract_prop(name) or ""
+                elif name.lower() in ("description", "desc", "content", "説明") and not description:
+                    description = extract_prop(name)
+
+        if not title:
+            title = f"Notion page {page_id[:8]}"
+
         return BugCreate(
-            title=title or "Notion Page",
+            title=title,
             description=description,
+            severity=severity,
+            priority=priority,
+            category=category,
+            version=version,
             source=Source.NOTION,
-            severity=Severity.MEDIUM,
-            priority=Priority.P2,
             external_ref=f"notion:page:{page_id}",
         )
 
@@ -75,25 +166,69 @@ class NotionConnector(ConnectorABC):
     async def fetch_schema(self, credentials: dict) -> list[dict]:
         """Return generic Notion page property fields."""
         return [
-            {"key": "properties.Name.title", "label": "ページタイトル"},
-            {"key": "properties.Description.rich_text", "label": "説明"},
-            {"key": "properties.Status.select", "label": "ステータス"},
+            {"key": "properties.Name", "label": "ページタイトル (Name)"},
+            {"key": "properties.Description", "label": "説明 (Description)"},
+            {"key": "properties.Status", "label": "ステータス (Status)"},
+            {"key": "properties.Priority", "label": "優先度 (Priority)"},
+            {"key": "properties.Severity", "label": "重大度 (Severity)"},
+            {"key": "properties.Type", "label": "タイプ (Type)"},
+            {"key": "properties.Version", "label": "バージョン (Version)"},
         ]
 
     async def query_database(
-        self, token: str, database_id: str, last_edited_after: str | None = None
+        self,
+        token: str,
+        database_id: str,
+        last_edited_after: str | None = None,
+        trigger_rules: dict | None = None,
     ) -> list[dict]:
+        """Query Notion database with optional time-based and property filters."""
         headers = {
             "Authorization": f"Bearer {token}",
             "Notion-Version": NOTION_VERSION,
             "Content-Type": "application/json",
         }
-        body: dict = {"page_size": 100}
+
+        filter_conditions: list[dict] = []
+
+        # Incremental sync: only pages edited after the last poll timestamp
         if last_edited_after:
-            body["filter"] = {
+            filter_conditions.append({
                 "timestamp": "last_edited_time",
                 "last_edited_time": {"after": last_edited_after},
-            }
+            })
+
+        # trigger_rules-based property filters
+        if trigger_rules:
+            # Single-value select filter (e.g. Status == "Bug")
+            status_field = trigger_rules.get("filter_by_status_field")
+            status_value = trigger_rules.get("filter_by_status_value")
+            if status_field and status_value:
+                filter_conditions.append({
+                    "property": status_field,
+                    "select": {"equals": status_value},
+                })
+
+            # Multi-select OR filter (e.g. Type contains "Bug" or "Issue")
+            type_field = trigger_rules.get("filter_by_type_field")
+            type_values = trigger_rules.get("filter_by_type_values")
+            if type_field and type_values:
+                values_list = type_values if isinstance(type_values, list) else [type_values]
+                type_conditions = [
+                    {"property": type_field, "multi_select": {"contains": v}}
+                    for v in values_list
+                ]
+                if len(type_conditions) == 1:
+                    filter_conditions.append(type_conditions[0])
+                else:
+                    filter_conditions.append({"or": type_conditions})
+
+        body: dict = {"page_size": 100}
+        if len(filter_conditions) == 1:
+            body["filter"] = filter_conditions[0]
+        elif len(filter_conditions) > 1:
+            body["filter"] = {"and": filter_conditions}
+
         async with httpx.AsyncClient(timeout=30.0) as client:
             try:
                 resp = await client.post(

--- a/backend/app/infrastructure/connectors/notion/polling.py
+++ b/backend/app/infrastructure/connectors/notion/polling.py
@@ -69,7 +69,10 @@ async def poll_notion_integrations() -> None:
                     if integration.last_received_at
                     else None
                 )
-                pages = await connector.query_database(token, database_id, last_ts)
+                pages = await connector.query_database(
+                    token, database_id, last_ts,
+                    trigger_rules=rules,  # Pass trigger_rules for Notion API-level filtering
+                )
 
                 for page in pages:
                     page_id = page.get("id", "")
@@ -80,8 +83,16 @@ async def poll_notion_integrations() -> None:
                     if await integration_repo.is_duplicate(str(integration.id), source_ref):
                         continue
 
+                    if integration.project_id is None:
+                        logger.warning(
+                            "Notion integration %s has no project_id; skipping page %s",
+                            integration.id,
+                            page_id,
+                        )
+                        continue
+
                     bug_create = await connector.transform(page, integration.field_mappings or [])
-                    bug = await bug_usecase.create_bug(bug_create)
+                    bug = await bug_usecase.create_bug(bug_create, str(integration.project_id))
                     await integration_repo.log_event(
                         str(integration.id),
                         "created",

--- a/frontend/src/features/integration-wizard/ui/Step3TriggerRules.tsx
+++ b/frontend/src/features/integration-wizard/ui/Step3TriggerRules.tsx
@@ -147,6 +147,44 @@ export function Step3TriggerRules({ sourceType, triggerRules, onRulesChange }: P
             <option value="60">60分</option>
           </select>
         </div>
+        <hr className="border-border" />
+        <p className="text-xs text-muted-foreground">
+          フィルター条件 — 指定した条件に一致するページのみバグとして取り込みます (省略可)
+        </p>
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label className="mb-1 block text-sm font-medium">Status フィールド名</label>
+            <input
+              className="w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+              placeholder="例: Status"
+              value={(rules.filter_by_status_field as string) ?? ""}
+              onChange={(e) => updateRule("filter_by_status_field", e.target.value || undefined)}
+            />
+          </div>
+          <div>
+            <label className="mb-1 block text-sm font-medium">フィルター値</label>
+            <input
+              className="w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+              placeholder="例: Bug"
+              value={(rules.filter_by_status_value as string) ?? ""}
+              onChange={(e) => updateRule("filter_by_status_value", e.target.value || undefined)}
+            />
+          </div>
+        </div>
+        <div>
+          <label className="mb-1 block text-sm font-medium">Type フィールド名 (複数値 OR)</label>
+          <input
+            className="w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+            placeholder="例: Type"
+            value={(rules.filter_by_type_field as string) ?? ""}
+            onChange={(e) => updateRule("filter_by_type_field", e.target.value || undefined)}
+          />
+        </div>
+        <TagInput
+          label="Type フィルター値 (どれか一致で取り込み)"
+          values={(rules.filter_by_type_values as string[]) ?? []}
+          onChange={(v) => updateRule("filter_by_type_values", v.length > 0 ? v : undefined)}
+        />
       </div>
     );
   }

--- a/frontend/src/features/integration-wizard/ui/Step4FieldMapping.tsx
+++ b/frontend/src/features/integration-wizard/ui/Step4FieldMapping.tsx
@@ -9,6 +9,8 @@ const VIGIL_FIELDS = [
   { key: "reported_by", label: "報告者" },
   { key: "severity", label: "重大度" },
   { key: "priority", label: "優先度" },
+  { key: "category", label: "カテゴリ" },
+  { key: "version", label: "バージョン" },
 ];
 
 type Props = {


### PR DESCRIPTION
## Summary

- Notionデータベースクエリに `trigger_rules` フィルタを追加（status/type フィールドのAPI側フィルタリング）
- `field_mappings` V2: Notionプロパティ型（title, rich_text, select, multi_select, date等）に対応した `extract_prop()` ヘルパーを実装
- マッピング設定で `property` キーを指定するだけで任意のNotionプロパティをバグフィールドにマッピング可能

## Test plan

- [ ] Slack連携設定 > Notion Step3 で trigger_rules を設定してフィルタが効くか確認
- [ ] field_mappings に property を指定してバグが正しくインポートされるか確認

Closes #37, #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)