### PR TITLE
feat: Stop the Line - 閾値超過アラート + ダッシュボードバナー + Slack通知

### DIFF
--- a/backend/alembic/versions/k7l8m9n0o1p2_add_stop_the_line_events.py
+++ b/backend/alembic/versions/k7l8m9n0o1p2_add_stop_the_line_events.py
@@ -1,0 +1,53 @@
+"""add stop_the_line_events table
+
+Revision ID: k7l8m9n0o1p2
+Revises: j6k7l8m9n0o1
+Create Date: 2026-03-16
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+revision = "k7l8m9n0o1p2"
+down_revision = "l8m9n0o1p2q3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "stop_the_line_events",
+        sa.Column(
+            "id",
+            UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "project_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("projects.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "triggered_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column("resolved_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("critical_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("high_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("threshold_critical", sa.Integer(), nullable=False),
+        sa.Column("threshold_high", sa.Integer(), nullable=False),
+    )
+    op.create_index(
+        "ix_stop_the_line_project_resolved",
+        "stop_the_line_events",
+        ["project_id", "resolved_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_stop_the_line_project_resolved", table_name="stop_the_line_events")
+    op.drop_table("stop_the_line_events")

--- a/backend/alembic/versions/l8m9n0o1p2q3_merge_bug_bash_and_main.py
+++ b/backend/alembic/versions/l8m9n0o1p2q3_merge_bug_bash_and_main.py
@@ -1,0 +1,21 @@
+"""merge bug_bash branch with main
+
+Revision ID: l8m9n0o1p2q3
+Revises: 29e3109fe4f2, j6k7l8m9n0o1
+Create Date: 2026-03-16
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "l8m9n0o1p2q3"
+down_revision = ("29e3109fe4f2", "j6k7l8m9n0o1")
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/backend/app/domain/models.py
+++ b/backend/app/domain/models.py
@@ -416,3 +416,33 @@ class BugBashSubmission(Base):
     __table_args__ = (
         UniqueConstraint("event_id", "bug_id", name="uq_bug_bash_submission"),
     )
+
+
+
+class StopTheLineEvent(Base):
+    """Records each time a stop-the-line condition was triggered for a project.
+
+    Used to deduplicate Slack notifications (only notify once per 4-hour window)
+    and to maintain an audit trail of quality gate breaches.
+    """
+
+    __tablename__ = "stop_the_line_events"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    project_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("projects.id", ondelete="CASCADE"), nullable=False
+    )
+    triggered_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    resolved_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    critical_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    high_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    threshold_critical: Mapped[int] = mapped_column(Integer, nullable=False)
+    threshold_high: Mapped[int] = mapped_column(Integer, nullable=False)
+
+    __table_args__ = (
+        Index("ix_stop_the_line_project_resolved", "project_id", "resolved_at"),
+    )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -22,7 +22,9 @@ from app.presentation.public import router as public_router
 from app.presentation.test_scenarios import router as test_scenarios_router
 from app.presentation.users import router as users_router
 from app.presentation.webhooks import router as webhooks_router
+from app.presentation.stop_the_line import router as stop_the_line_router
 from app.presentation.workflow_columns import router as workflow_columns_router
+from app.scheduler.stop_the_line import check_stop_the_line
 from app.scheduler.test_reminder import send_test_checklist_reminders
 
 app = FastAPI(title="Vigil", description="Bug tracking dashboard for archaive")
@@ -56,6 +58,7 @@ app.include_router(public_router)
 app.include_router(test_scenarios_router)
 app.include_router(users_router)
 app.include_router(webhooks_router)
+app.include_router(stop_the_line_router)
 app.include_router(workflow_columns_router)
 
 
@@ -71,6 +74,8 @@ async def startup() -> None:
     scheduler.add_job(
         send_test_checklist_reminders, "cron", hour=10, minute=0, id="test_reminder"
     )
+    # Every 30 minutes: check stop-the-line thresholds and notify Slack if exceeded
+    scheduler.add_job(check_stop_the_line, "interval", minutes=30, id="stop_the_line_check")
     scheduler.start()
 
 

--- a/backend/app/presentation/stop_the_line.py
+++ b/backend/app/presentation/stop_the_line.py
@@ -1,0 +1,82 @@
+"""Stop the Line API endpoint.
+
+Returns the current stop-the-line status for the authenticated project:
+whether the quality gate is triggered and the current critical/high bug counts
+vs. their configured thresholds.
+
+Thresholds are stored in the Slack integration's trigger_rules JSONB field
+under the keys `stop_the_line_critical` (default: 3) and
+`stop_the_line_high` (default: 10).
+"""
+import uuid
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.di.auth import ProjectAuthContext, verify_project_membership
+from app.domain.models import Bug, Integration
+from app.infrastructure.db.database import get_session
+
+router = APIRouter(prefix="/api/stop-the-line", tags=["stop-the-line"])
+
+_DEFAULT_THRESHOLD_CRITICAL = 3
+_DEFAULT_THRESHOLD_HIGH = 10
+
+
+class StopTheLineStatus(BaseModel):
+    is_triggered: bool
+    critical_count: int
+    high_count: int
+    threshold_critical: int
+    threshold_high: int
+
+
+@router.get("/status", response_model=StopTheLineStatus)
+async def get_status(
+    _auth: ProjectAuthContext = Depends(verify_project_membership),
+    session: AsyncSession = Depends(get_session),
+) -> StopTheLineStatus:
+    """Return the current stop-the-line status for the project."""
+    pid = uuid.UUID(_auth.project_id)
+
+    # Load thresholds from the project's active Slack integration trigger_rules.
+    # Falls back to defaults if no Slack integration is configured.
+    slack_integration = await session.scalar(
+        select(Integration)
+        .where(
+            Integration.project_id == pid,
+            Integration.source_type == "slack",
+            Integration.is_active.is_(True),
+        )
+        .limit(1)
+    )
+    rules = (slack_integration.trigger_rules or {}) if slack_integration else {}
+    threshold_critical = int(rules.get("stop_the_line_critical", _DEFAULT_THRESHOLD_CRITICAL))
+    threshold_high = int(rules.get("stop_the_line_high", _DEFAULT_THRESHOLD_HIGH))
+
+    critical_count = await session.scalar(
+        select(func.count()).where(
+            Bug.project_id == pid,
+            Bug.severity == "critical",
+            Bug.status != "closed",
+        )
+    ) or 0
+    high_count = await session.scalar(
+        select(func.count()).where(
+            Bug.project_id == pid,
+            Bug.severity == "high",
+            Bug.status != "closed",
+        )
+    ) or 0
+
+    is_triggered = (critical_count >= threshold_critical) or (high_count >= threshold_high)
+
+    return StopTheLineStatus(
+        is_triggered=is_triggered,
+        critical_count=critical_count,
+        high_count=high_count,
+        threshold_critical=threshold_critical,
+        threshold_high=threshold_high,
+    )

--- a/backend/app/scheduler/stop_the_line.py
+++ b/backend/app/scheduler/stop_the_line.py
@@ -1,0 +1,150 @@
+"""APScheduler job: Stop the Line quality gate check.
+
+Schedule: every 30 minutes.
+
+Logic:
+- Counts open critical and high bugs per project.
+- If either count meets or exceeds the configured threshold, the line is stopped.
+- A Slack notification is sent at most once per 4-hour window to avoid spam.
+- Each triggering event is persisted to stop_the_line_events for audit purposes.
+"""
+import logging
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import func, select
+
+from app.infrastructure.connectors.encryption import CredentialDecryptionError, decrypt_credentials
+from app.infrastructure.db.database import async_session
+from app.domain.models import Bug, Integration, StopTheLineEvent
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_THRESHOLD_CRITICAL = 3
+_DEFAULT_THRESHOLD_HIGH = 10
+_NOTIFICATION_COOLDOWN_HOURS = 4
+
+
+async def check_stop_the_line() -> None:
+    """Check all active projects for stop-the-line conditions and notify Slack."""
+    async with async_session() as session:
+        integrations = (
+            await session.execute(
+                select(Integration).where(
+                    Integration.source_type == "slack",
+                    Integration.is_active.is_(True),
+                    Integration.project_id.isnot(None),
+                )
+            )
+        ).scalars().all()
+
+        for integration in integrations:
+            pid = integration.project_id
+            rules = integration.trigger_rules or {}
+            threshold_critical = int(rules.get("stop_the_line_critical", _DEFAULT_THRESHOLD_CRITICAL))
+            threshold_high = int(rules.get("stop_the_line_high", _DEFAULT_THRESHOLD_HIGH))
+
+            critical_count = await session.scalar(
+                select(func.count()).where(
+                    Bug.project_id == pid,
+                    Bug.severity == "critical",
+                    Bug.status != "closed",
+                )
+            ) or 0
+            high_count = await session.scalar(
+                select(func.count()).where(
+                    Bug.project_id == pid,
+                    Bug.severity == "high",
+                    Bug.status != "closed",
+                )
+            ) or 0
+
+            is_triggered = (critical_count >= threshold_critical) or (high_count >= threshold_high)
+            if not is_triggered:
+                continue
+
+            # Suppress repeat notifications within the cooldown window.
+            cooldown_cutoff = datetime.now(timezone.utc) - timedelta(hours=_NOTIFICATION_COOLDOWN_HOURS)
+            recent_event_count = await session.scalar(
+                select(func.count()).where(
+                    StopTheLineEvent.project_id == pid,
+                    StopTheLineEvent.triggered_at > cooldown_cutoff,
+                )
+            ) or 0
+            if recent_event_count > 0:
+                logger.debug(
+                    "Stop the Line already triggered for project %s within cooldown window; skipping",
+                    pid,
+                )
+                continue
+
+            # Persist the event before attempting notification so it is always recorded.
+            event = StopTheLineEvent(
+                project_id=pid,
+                critical_count=critical_count,
+                high_count=high_count,
+                threshold_critical=threshold_critical,
+                threshold_high=threshold_high,
+            )
+            session.add(event)
+            await session.commit()
+
+            channel = rules.get("notification_channel", "")
+            if not channel:
+                logger.debug(
+                    "No notification_channel configured for project %s; skipping Slack post", pid
+                )
+                continue
+
+            await _post_to_slack(integration, channel, critical_count, high_count, threshold_critical, threshold_high)
+
+
+async def _post_to_slack(
+    integration: Integration,
+    channel: str,
+    critical_count: int,
+    high_count: int,
+    threshold_critical: int,
+    threshold_high: int,
+) -> None:
+    """Post a stop-the-line alert to the configured Slack channel."""
+    import httpx
+
+    try:
+        credentials = decrypt_credentials(integration.credentials_enc)
+    except CredentialDecryptionError:
+        logger.warning(
+            "Failed to decrypt Slack credentials for project %s; skipping notification",
+            integration.project_id,
+        )
+        return
+
+    bot_token = credentials.get("bot_token", "")
+    if not bot_token:
+        return
+
+    message = (
+        f":rotating_light: *Stop the Line!*\n"
+        f"Open critical bugs: *{critical_count}* (threshold: {threshold_critical})\n"
+        f"Open high bugs: *{high_count}* (threshold: {threshold_high})\n"
+        f"Review and resolve critical/high bugs before continuing new work."
+    )
+
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                "https://slack.com/api/chat.postMessage",
+                json={"channel": channel, "text": message},
+                headers={"Authorization": f"Bearer {bot_token}"},
+                timeout=10,
+            )
+        if not resp.json().get("ok"):
+            logger.warning(
+                "Stop the Line Slack post failed for project %s: %s",
+                integration.project_id,
+                resp.text,
+            )
+    except Exception:
+        logger.exception(
+            "Error posting Stop the Line notification for project %s",
+            integration.project_id,
+        )

--- a/frontend/src/entities/stop-the-line/api/stop-the-line-api.ts
+++ b/frontend/src/entities/stop-the-line/api/stop-the-line-api.ts
@@ -1,0 +1,13 @@
+import { apiClient } from "@/src/shared/api/client";
+
+export type StopTheLineStatus = {
+  is_triggered: boolean;
+  critical_count: number;
+  high_count: number;
+  threshold_critical: number;
+  threshold_high: number;
+};
+
+export async function fetchStopTheLineStatus(): Promise<StopTheLineStatus> {
+  return apiClient<StopTheLineStatus>("/api/stop-the-line/status");
+}

--- a/frontend/src/features/integration-wizard/ui/Step3TriggerRules.tsx
+++ b/frontend/src/features/integration-wizard/ui/Step3TriggerRules.tsx
@@ -72,6 +72,64 @@ export function Step3TriggerRules({ sourceType, triggerRules, onRulesChange }: P
           values={(rules.keywords as string[]) ?? []}
           onChange={(v) => updateRule("keywords", v)}
         />
+
+        <div className="rounded-md border border-dashed p-3 space-y-3">
+          <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+            Stop the Line しきい値
+          </p>
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="mb-1 block text-sm font-medium">
+                Critical バグ上限
+              </label>
+              <input
+                type="number"
+                min={1}
+                className="w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+                value={(rules.stop_the_line_critical as number) ?? 3}
+                onChange={(e) =>
+                  updateRule("stop_the_line_critical", Number(e.target.value))
+                }
+              />
+              <p className="mt-1 text-xs text-muted-foreground">
+                この件数以上でアラート
+              </p>
+            </div>
+            <div>
+              <label className="mb-1 block text-sm font-medium">
+                High バグ上限
+              </label>
+              <input
+                type="number"
+                min={1}
+                className="w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+                value={(rules.stop_the_line_high as number) ?? 10}
+                onChange={(e) =>
+                  updateRule("stop_the_line_high", Number(e.target.value))
+                }
+              />
+              <p className="mt-1 text-xs text-muted-foreground">
+                この件数以上でアラート
+              </p>
+            </div>
+          </div>
+          <div>
+            <label className="mb-1 block text-sm font-medium">
+              通知チャンネル
+            </label>
+            <input
+              className="w-full rounded-md border bg-background px-3 py-2 text-sm font-mono focus:outline-none focus:ring-1 focus:ring-ring"
+              placeholder="#alerts または C01XXXXX"
+              value={(rules.notification_channel as string) ?? ""}
+              onChange={(e) =>
+                updateRule("notification_channel", e.target.value)
+              }
+            />
+            <p className="mt-1 text-xs text-muted-foreground">
+              Stop the Line 通知の送信先 Slack チャンネル
+            </p>
+          </div>
+        </div>
       </div>
     );
   }

--- a/frontend/src/pages/dashboard/ui/DashboardPage.tsx
+++ b/frontend/src/pages/dashboard/ui/DashboardPage.tsx
@@ -7,6 +7,7 @@ import { listWorkflowColumns } from "@/src/entities/workflow-column/api/workflow
 import type { WorkflowColumn } from "@/src/entities/workflow-column/model/types";
 import { ViewToggle } from "@/src/features/view-toggle/ui/ViewToggle";
 import { StatsCards } from "@/src/widgets/stats-cards/ui/StatsCards";
+import { StopTheLineBanner } from "@/src/widgets/stop-the-line/ui/StopTheLineBanner";
 import { BugList } from "@/src/widgets/bug-list/ui/BugList";
 
 export function DashboardPage() {
@@ -25,6 +26,8 @@ export function DashboardPage() {
 
   return (
     <div className="space-y-6">
+      <StopTheLineBanner />
+
       <div className="flex items-center justify-between">
         <h1 className="text-lg font-semibold tracking-tight">Issues</h1>
         <ViewToggle />

--- a/frontend/src/widgets/stop-the-line/ui/StopTheLineBanner.tsx
+++ b/frontend/src/widgets/stop-the-line/ui/StopTheLineBanner.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { AlertTriangle, X } from "lucide-react";
+import {
+  fetchStopTheLineStatus,
+  type StopTheLineStatus,
+} from "@/src/entities/stop-the-line/api/stop-the-line-api";
+
+export function StopTheLineBanner() {
+  const [status, setStatus] = useState<StopTheLineStatus | null>(null);
+  const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    fetchStopTheLineStatus()
+      .then(setStatus)
+      .catch(() => {
+        // Non-critical: silently ignore fetch errors (e.g. no Slack integration configured)
+      });
+  }, []);
+
+  if (!status?.is_triggered || dismissed) return null;
+
+  return (
+    <div className="flex items-start gap-3 rounded-lg border border-red-500/40 bg-red-500/10 px-4 py-3 text-[13px]">
+      <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-red-400" />
+      <div className="flex-1">
+        <span className="font-semibold text-red-300">Stop the Line</span>
+        <span className="ml-2 text-red-200/80">
+          Critical: {status.critical_count}/{status.threshold_critical}件　High:{" "}
+          {status.high_count}/{status.threshold_high}件
+        </span>
+        <span className="ml-2 text-red-200/60">
+          — 未解決の重大バグがしきい値を超えています。新規開発より先にバグ対応を優先してください。
+        </span>
+      </div>
+      <button
+        type="button"
+        onClick={() => setDismissed(true)}
+        className="text-red-400/60 hover:text-red-300"
+        aria-label="バナーを閉じる"
+      >
+        <X className="h-4 w-4" />
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- `StopTheLineEvent` テーブルを追加（Alembicマイグレーション済み）
- `GET /api/stop-the-line/status` エンドポイント: 未解決バグ数・閾値・アクティブ状態を返す
- APScheduler で30分ごとに閾値チェック → 超過時は Slack に通知（4時間以内の重複通知を抑制）
- ダッシュボードに `StopTheLineBanner` コンポーネントを追加（閾値超過時のみ表示）
- Slackインテグレーション Step3 で critical/high 閾値を設定可能

## Test plan

- [ ] Slackインテグレーションで閾値を低く設定し、バグを登録してバナーが表示されること
- [ ] `/api/stop-the-line/status` が正しいバグ数・閾値を返すこと

Closes #53, #54, #55, #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)